### PR TITLE
Add github action that creates a comment with coverage report on pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: 'Test'
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'Install Node'
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+    - name: 'Install Deps'
+      run: npm install
+    - name: 'Test'
+      run: npx vitest --coverage
+    - name: 'Report Coverage'
+      if: always() # Also generate the report if tests are failing
+      uses:  davelosert/vitest-coverage-report-action@v2


### PR DESCRIPTION
Solves https://github.com/csaf-poc/csaf_webview/issues/2

Adds the vitest coverage check to any PR. Check can be configured via https://github.com/csaf-poc/csaf_webview/blob/main/vite.config.ts.

Action will start the check when a Pull Request is created, then the bot will comment the result. This PR contains an example.