### PR TITLE
fix: Index of distributions

### DIFF
--- a/src/lib/feedview/feed/distributions/Distributions.svelte
+++ b/src/lib/feedview/feed/distributions/Distributions.svelte
@@ -11,18 +11,22 @@
   import { appStore } from "$lib/store";
   import Collapsible from "$lib/Collapsible.svelte";
   import Distribution from "./Distribution.svelte";
+
+  const getDistributions = () => {
+    return $appStore.providerMetadata["distributions"].filter(
+      (d: any) => d.rolie?.feeds !== undefined
+    );
+  };
 </script>
 
 {#if $appStore.providerMetadata}
-  {#each $appStore.providerMetadata["distributions"] as distribution, index}
-    {#if distribution.rolie && distribution.rolie.feeds}
-      <Collapsible
-        header={`Distribution ${index + 1}`}
-        level="3"
-        open={$appStore.providerMetadata["distributions"].length === 1}
-      >
-        <Distribution {distribution} />
-      </Collapsible>
-    {/if}
+  {#each getDistributions() as distribution, index}
+    <Collapsible
+      header={`Distribution ${index + 1}`}
+      level="3"
+      open={$appStore.providerMetadata["distributions"].length === 1}
+    >
+      <Distribution {distribution} />
+    </Collapsible>
   {/each}
 {/if}


### PR DESCRIPTION
Only increment the index when the distribution actually contains feeds.

#37 was already fixed by the commit mentioned in a [comment](https://github.com/csaf-poc/csaf_webview/issues/37#issuecomment-1934461941). But the index that was shown in front of the distribution didn't look correct for users. In the example with https://csaf-poc.github.io/csaf_webview/feed?q=https://csaf.data.security.nozominetworks.com/provider-metadata.json the first distribution was displayed as "Distribution 2" which might confuse users because they might think that there should be another one with index 1 although it is technically correct because it is the second distribution in the array in the file.